### PR TITLE
Fix deprecation warning in node 8

### DIFF
--- a/components/auth.js
+++ b/components/auth.js
@@ -34,7 +34,7 @@ function Auth(config) {
 
     // save them for later
     mkdirp(path.dirname(config.savedTokensPath), () => {
-      fs.writeFile(config.savedTokensPath, JSON.stringify(tokens));
+      fs.writeFile(config.savedTokensPath, JSON.stringify(tokens), () => {});
     });
   };
 


### PR DESCRIPTION
Node 8 deprecates not passing a callback to async functions and prints a warning.