### PR TITLE
Adds a configurable function to accept auth tokens.

### DIFF
--- a/components/auth.js
+++ b/components/auth.js
@@ -51,7 +51,7 @@ function Auth(config) {
     // if tokenInput is configured
     // run the tokenInput function to accept the token code
     if (typeof config.tokenInput === 'function') {
-      config.tokenInput(processToken);
+      config.tokenInput(processTokens);
       return;
     }
 
@@ -62,7 +62,7 @@ function Auth(config) {
       terminal: false,
     });
 
-    reader.question('Paste your code: ', processToken);
+    reader.question('Paste your code: ', processTokens);
   };
 
   const processTokens = (oauthCode) => {

--- a/components/auth.js
+++ b/components/auth.js
@@ -48,6 +48,13 @@ function Auth(config) {
     opn(url);
     console.log('Attempted to automatically open the URL, but if it failed, copy/paste this in your browser:\n', url);
 
+    // if tokenInput is configured
+    // run the tokenInput function to accept the token code
+    if (typeof config.tokenInput === 'function') {
+      config.tokenInput(processToken);
+      return;
+    }
+
     // create the interface to accept the code
     const reader = readline.createInterface({
       input: process.stdin,
@@ -55,20 +62,22 @@ function Auth(config) {
       terminal: false,
     });
 
-    reader.question('Paste your code: ', (oauthCode) => {
-      if (!oauthCode) process.exit(-1);
+    reader.question('Paste your code: ', processToken);
+  };
 
-      // get our tokens to save
-      oauthClient.getToken(oauthCode, (error, tkns) => {
-        // if we didn't have an error, save the tokens
-        if (error) {
-          console.log('Error getting tokens:', error);
-          return;
-        }
+  const processTokens = (oauthCode) => {
+    if (!oauthCode) process.exit(-1);
 
-        tokens = tkns;
-        saveTokens();
-      });
+    // get our tokens to save
+    oauthClient.getToken(oauthCode, (error, tkns) => {
+      // if we didn't have an error, save the tokens
+      if (error) {
+        console.log('Error getting tokens:', error);
+        return;
+      }
+
+      tokens = tkns;
+      saveTokens();
     });
   };
 


### PR DESCRIPTION
I needed to use this Google Assistant library with Electron so I needed to accept tokens in the UI instead of the terminal. This adds a new configuration property called `tokenInput`. It's a function that accepts a callback, which is passed some value, which should be the access token.

Here is an example using the `prompt` function, which isn't available in Electron, but is easy to understand for the sake of this pull request.

```
var assistant = new GoogleAssistant({
	auth: {
		keyFilePath: 'YOUR_API_KEY_FILE_PATH.json',
		savedTokensPath: 'SOME_PATH/tokens.js',
		tokenInput: function(callback) {
			var token = prompt('Please provide your OAuth token.');
			callback(value);
		},
	},
});
```