### PR TITLE
V Minor: Update README to show passing down of config.conversation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const startConversation = (conversation) => {
 // will start a conversation and wait for audio data
 // as soon as it's ready
 assistant
-  .on('ready', () => assistant.start())
+  .on('ready', () => assistant.start(config.conversation))
   .on('started', startConversation);
 ```
 


### PR DESCRIPTION
Pass `config.conversation` to `start` - forgetting to do this returns a `Service unavailable.` response.