### PR TITLE
Support for `web` client IDs

### DIFF
--- a/components/auth.js
+++ b/components/auth.js
@@ -23,7 +23,8 @@ function Auth(config) {
     return;
   }
 
-  const key = require(config.keyFilePath).installed;
+  const keyData = require(config.keyFilePath);
+  const key = keyData.installed || keyData.web;
   const oauthClient = new OAuth2(key.client_id, key.client_secret, key.redirect_uris[0]);
   let tokens;
 


### PR DESCRIPTION
If the downloaded client secret is for a `web` application instead of an `installed` application, the object in the JSON file will be called `web` instead of `installed`, which causes `auth.js` to crash (see [this page](https://developers.google.com/api-client-library/python/guide/aaa_client_secrets) for more info). This commit adds support for both types of client secrets. Tested and works well.