### PR TITLE
refresh expired token

### DIFF
--- a/components/auth.js
+++ b/components/auth.js
@@ -81,7 +81,7 @@ function Auth(config) {
   };
 
   // if the tokens are already saved, we can skip having to get the code for now
-  process.nextTick(() => {
+  process.nextTick(async () => {
     if (config.savedTokensPath) {
       try {
         const tokensFile = fs.readFileSync(config.savedTokensPath);

--- a/components/auth.js
+++ b/components/auth.js
@@ -90,7 +90,16 @@ function Auth(config) {
         // we need to get the tokens
         getTokens();
       } finally {
-        if (tokens !== undefined) saveTokens();
+        if (tokens !== undefined) {
+          oauthClient.setCredentials(tokens);
+          // verify if the token is expired
+          if (tokens.expiry_date < Date.now()) {
+            // refresh the token if expired
+            let ret = await oauthClient.refreshAccessToken()
+            tokens = ret.credentials;
+          }
+          saveTokens();
+        }
       }
     }
   });


### PR DESCRIPTION
Fixed issue https://github.com/endoplasmic/google-assistant/issues/95

It appears the token is not refresh… so when we reach the expiry date, it will return an `invalid_grant`.